### PR TITLE
Use Python 3 in PATH

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Revision history for {{$dist->name}}
 
 {{$NEXT}}
+  - Look for Python 3 to run Meson script.
+    See <https://github.com/PerlAlien/Alien-Meson/pull/3>.
 
 0.01      2021-11-27 21:33:35-05:00 America/New_York
   - initial version

--- a/alienfile
+++ b/alienfile
@@ -9,12 +9,29 @@ plugin 'Probe::CommandLine' => (
 
 share {
   requires 'Path::Tiny';
+  requires 'File::Which';
+  requires 'Capture::Tiny';
   start_url 'https://github.com/mesonbuild/meson/releases';
   plugin Download => (
     filter  => qr/^meson-.*\.tar\.gz$/,
     version => qr/([0-9\.]+)/,
   );
   plugin 'Extract::CommandLine' => 'tar.gz';
+  my $python_bin;
+  PYTHON_BIN:
+  for my $test_python_bin ( qw(python3 python) ) {
+    if(
+      File::Which::which($test_python_bin)
+      &&
+      Capture::Tiny::capture(sub {
+            system( $test_python_bin, qw( --version ) )
+      }) =~ /^Python 3/
+    ) {
+      $python_bin = $test_python_bin;
+      last PYTHON_BIN;
+    }
+  }
+  die "No Python3 found" unless defined $python_bin;
   patch sub {
     my @tests = Path::Tiny::path('.')->children( qr/.*test.*/ );
     $_->remove_tree for @tests;
@@ -26,5 +43,6 @@ share {
     my($build) = @_;
     $build->runtime_prop->{'python-source'} = 1;
     $build->runtime_prop->{command} = 'meson.py';
+    $build->runtime_prop->{python_bin} = $python_bin;
   };
 }

--- a/lib/Alien/Meson.pm
+++ b/lib/Alien/Meson.pm
@@ -45,7 +45,6 @@ Returns the command name for running meson.
 sub exe {
   my($class) = @_;
   if( $class->install_type('share')
-    && $^O eq 'MSWin32'
     && $class->runtime_prop->{'python-source'}
     ) {
     return (

--- a/lib/Alien/Meson.pm
+++ b/lib/Alien/Meson.pm
@@ -48,7 +48,9 @@ sub exe {
     && $^O eq 'MSWin32'
     && $class->runtime_prop->{'python-source'}
     ) {
-    return ( 'python3', Path::Tiny->new( $class->bin_dir, $class->runtime_prop->{command}) );
+    return (
+      $class->runtime_prop->{python_bin},
+      Path::Tiny->new( $class->bin_dir, $class->runtime_prop->{command} ) );
   }
   $class->runtime_prop->{command};
 }


### PR DESCRIPTION
- Check for Python 3 in PATH for share install
- Use explicit Python on all OSes (not the shebang)
