### PR TITLE
Add ALIEN_MESON_SHARE_PREFER environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,19 +61,21 @@ jobs:
         os: [ubuntu-latest]
         perl-version: ['5.8', '5.20', '5.30', '5.34']
         alien-install-type: [ 'system', 'share' ]
-        alien-meson-from-source: [ false ] # false is the default for $ALIEN_MESON_FROM_SOURCE
+        alien-meson-share-prefer: [ 'auto' ] # auto is the default for $ALIEN_MESON_SHARE_PREFER
         include:
-          # Windows strawberry     | (share, toggle from-source)
-          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'                                  }
-          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'  , alien-meson-from-source: true }
-          # Windows msys2          | system, (share, toggle from-source)
-          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'system'                                 }
-          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'                                  }
-          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'  , alien-meson-from-source: true }
+          # Windows strawberry     | (share, toggle share-prefer)
+          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'  , alien-meson-share-prefer: 'auto'   }
+          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'  , alien-meson-share-prefer: 'binary' }
+          - { perl-version: '5.34' , os: windows-latest , dist: strawberry , alien-install-type: 'share'  , alien-meson-share-prefer: 'source' }
+          # Windows msys2          | system, (share, toggle share-prefer)
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'system'                                      }
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'  , alien-meson-share-prefer: 'auto'   }
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'  , alien-meson-share-prefer: 'binary' }
+          - { perl-version: '5.34' , os: windows-latest , dist: msys2      , alien-install-type: 'share'  , alien-meson-share-prefer: 'source' }
           # macOS                  | system, share
-          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'system'                                 }
-          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'share'                                  }
-    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }} with install-type ${{ matrix.alien-install-type }}, dist ${{ matrix.dist }}, from-source ${{ !! matrix.alien-meson-from-source }}
+          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'system'                                      }
+          - { perl-version: '5.34' , os: macos-11       ,                    alien-install-type: 'share'                                       }
+    name: Perl ${{ matrix.perl-version }} on ${{ matrix.os }} with install-type ${{ matrix.alien-install-type }}, dist ${{ matrix.dist }}, share-prefer ${{ matrix.alien-meson-share-prefer || 'auto' }}
 
     steps:
       - name: Get dist artifact
@@ -136,11 +138,11 @@ jobs:
         run: |
           echo "ALIEN_INSTALL_TYPE=${{ matrix.alien-install-type }}" >> $GITHUB_ENV
 
-      - name: Set ALIEN_MESON_FROM_SOURCE
-        if: matrix.alien-meson-from-source
+      - name: Set ALIEN_MESON_SHARE_PREFER
+        if: matrix.alien-meson-share-prefer
         shell: bash
         run: |
-          echo "ALIEN_MESON_FROM_SOURCE=${{ fromJSON( '["0", "1"]')[ matrix.alien-meson-from-source ] }}" >> $GITHUB_ENV
+          echo "ALIEN_MESON_SHARE_PREFER=${{ matrix.alien-meson-share-prefer }}" >> $GITHUB_ENV
 
       - name: Run tests
         run: |

--- a/alienfile
+++ b/alienfile
@@ -119,30 +119,40 @@ share {
 
   $ENV{ALIEN_MESON_SHARE_PREFER} ||= 'auto';
 
+  my $release_types = {
+    source => {
+      'can' => \&can_source,
+      'do'  => \&do_source,
+    },
+    binary => {
+      'can' => \&can_binary,
+      'do'  => \&do_binary,
+    },
+  };
+
   if( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'auto' ) {
-    eval { can_source() };
-    my $source_catch = $@;
-    warn "Unable to install from source: $source_catch"
-      if $source_catch;
+    my $which_type;
+    my @types = qw(source binary);
+    for my $type (@types) {
+      eval { $release_types->{$type}{can}->() };
+      my $catch = $@;
+      if( $catch ) {
+        warn "Unable to install release type $type: $catch";
+	next;
+      }
 
-    eval { can_binary() };
-    my $binary_catch = $@;
-    warn "Unable to install from binary: $binary_catch"
-      if $binary_catch;
-
-    if( ! $source_catch ) {
-      do_source();
-    }  elsif( ! $binary_catch ) {
-      do_binary();
-    } else {
-      die "Unable to install source nor binary release";
+      $which_type = $type;
+      $release_types->{$type}{do}->();
+      last;
     }
-  } elsif( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'binary' ) {
-    can_binary();
-    do_binary();
-  } elsif( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'source') {
-    can_source();
-    do_source();
+
+    if( ! $which_type ) {
+      die "Unable to install from release types: @types";
+    }
+  } elsif( exists $release_types->{ $ENV{ALIEN_MESON_SHARE_PREFER} } ) {
+    $release_types->{ $ENV{ALIEN_MESON_SHARE_PREFER} }{$_}->() for qw(can do);
+  } else {
+    die "Unknown value for ALIEN_MESON_SHARE_PREFER: $ENV{ALIEN_MESON_SHARE_PREFER}";
   }
 
 };

--- a/alienfile
+++ b/alienfile
@@ -1,7 +1,11 @@
 use alienfile;
 use Config;
 
-# NOTE: you can set ALIEN_MESON_FROM_SOURCE to force a build from source.
+# NOTE: you can set ALIEN_MESON_SHARE_PREFER to either:
+#
+# - "auto": try source install then try binary install (default)
+# - "source": try source install only
+# - "binary": try binary install only
 
 plugin 'Probe::CommandLine' => (
   command => $_,
@@ -9,6 +13,99 @@ plugin 'Probe::CommandLine' => (
   match   => qr/([0-9\.]+)/,
   version => qr/([0-9\.]+)/,
 ) for qw( meson.py meson );
+
+my $python_bin;
+sub can_source {
+  for my $test_python_bin ( qw(python3 python) ) {
+    if(
+      File::Which::which($test_python_bin)
+      &&
+      Capture::Tiny::capture(sub {
+            system( $test_python_bin, qw( --version ) )
+      }) =~ /^Python 3/
+    ) {
+      $python_bin = $test_python_bin;
+      return;
+    }
+  }
+
+  die "No Python3 found" unless defined $python_bin;
+}
+
+sub do_source {
+  # Python source
+  plugin Download => (
+    filter  => qr/^meson-.*\.tar\.gz$/,
+    version => qr/([0-9\.]+)/,
+  );
+  plugin 'Extract::CommandLine' => 'tar.gz';
+  patch sub {
+    my @tests = Path::Tiny::path('.')->children( qr/.*test.*/ );
+    $_->remove_tree for @tests;
+    Path::Tiny::path('graphics')->remove_tree;
+    Path::Tiny::path('setup.py')->remove_tree;
+  };
+  plugin 'Build::Copy';
+  after build => sub {
+    my($build) = @_;
+    $build->runtime_prop->{'style'} = 'source';
+    $build->runtime_prop->{'python-source'} = 1;
+    $build->runtime_prop->{command} = 'meson.py';
+    $build->runtime_prop->{python_bin} = $python_bin;
+  };
+}
+
+my ($binary_release_name_re, $binary_release_format);
+sub can_binary {
+  if( $^O eq 'MSWin32' && $Config{ptrsize} == 8 ) {
+    # Windows 64-bit
+    $binary_release_name_re = qr/meson-.*-64\.msi/;
+    $binary_release_format = '.msi';
+    return;
+  }
+
+  die "No binary packages available for this configuration";
+}
+
+sub do_binary {
+  plugin Download => (
+    filter  => $binary_release_name_re,
+    version => qr/([0-9\.]+)/,
+  );
+
+  if( $binary_release_format eq '.msi' ) {
+    extract sub {
+      my ($build) = @_;
+
+      my $msi = Path::Tiny::path($build->install_prop->{download})->canonpath;
+      my $cwd = Path::Tiny->cwd->canonpath;
+
+      Alien::Build::CommandSequence->new([
+        qw(msiexec /a),
+        $msi,
+        "TARGETDIR=$cwd",
+        '/qn'
+      ])->execute($build);
+    };
+
+    patch sub {
+      my $cwd = Path::Tiny->cwd;
+      $_->remove for $cwd->children( qr/\.msi$/ );
+      my $Meson = $cwd->child('Meson');
+      $Meson->child('ninja.exe')->remove;
+      File::Copy::Recursive::rmove( "$Meson/*", $cwd );
+      $Meson->remove_tree;
+    };
+
+    plugin 'Build::Copy';
+
+    after build => sub {
+      my($build) = @_;
+      $build->runtime_prop->{'style'} = 'binary';
+      $build->runtime_prop->{command} = 'meson';
+    };
+  }
+}
 
 share {
   requires 'Path::Tiny';
@@ -20,87 +117,32 @@ share {
   # same URL used for both source and binary releases
   start_url 'https://github.com/mesonbuild/meson/releases';
 
-  my ($binary_release_name_re, $binary_release_format);
-  if( $^O eq 'MSWin32' && $Config{ptrsize} == 8 ) {
-    # Windows 64-bit
-    $binary_release_name_re = qr/meson-.*-64\.msi/;
-    $binary_release_format = '.msi';
-  }
+  $ENV{ALIEN_MESON_SHARE_PREFER} ||= 'auto';
 
-  if($binary_release_format && !$ENV{ALIEN_MESON_FROM_SOURCE}) {
-    plugin Download => (
-      filter  => $binary_release_name_re,
-      version => qr/([0-9\.]+)/,
-    );
+  if( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'auto' ) {
+    eval { can_source() };
+    my $source_catch = $@;
+    warn "Unable to install from source: $source_catch"
+      if $source_catch;
 
-    if( $binary_release_format eq '.msi' ) {
-      extract sub {
-        my ($build) = @_;
+    eval { can_binary() };
+    my $binary_catch = $@;
+    warn "Unable to install from binary: $binary_catch"
+      if $binary_catch;
 
-        my $msi = Path::Tiny::path($build->install_prop->{download})->canonpath;
-        my $cwd = Path::Tiny->cwd->canonpath;
-
-        Alien::Build::CommandSequence->new([
-          qw(msiexec /a),
-          $msi,
-          "TARGETDIR=$cwd",
-          '/qn'
-        ])->execute($build);
-      };
-
-      patch sub {
-        my $cwd = Path::Tiny->cwd;
-        $_->remove for $cwd->children( qr/\.msi$/ );
-        my $Meson = $cwd->child('Meson');
-        $Meson->child('ninja.exe')->remove;
-        File::Copy::Recursive::rmove( "$Meson/*", $cwd );
-        $Meson->remove_tree;
-      };
-
-      plugin 'Build::Copy';
-
-      after build => sub {
-        my($build) = @_;
-        $build->runtime_prop->{'style'} = 'binary';
-        $build->runtime_prop->{command} = 'meson';
-      };
+    if( ! $source_catch ) {
+      do_source();
+    }  elsif( ! $binary_catch ) {
+      do_binary();
+    } else {
+      die "Unable to install source nor binary release";
     }
-  } else {
-    # Python source
-    plugin Download => (
-      filter  => qr/^meson-.*\.tar\.gz$/,
-      version => qr/([0-9\.]+)/,
-    );
-    plugin 'Extract::CommandLine' => 'tar.gz';
-    my $python_bin;
-    PYTHON_BIN:
-    for my $test_python_bin ( qw(python3 python) ) {
-      if(
-        File::Which::which($test_python_bin)
-        &&
-        Capture::Tiny::capture(sub {
-              system( $test_python_bin, qw( --version ) )
-        }) =~ /^Python 3/
-      ) {
-        $python_bin = $test_python_bin;
-        last PYTHON_BIN;
-      }
-    }
-    die "No Python3 found" unless defined $python_bin;
-    patch sub {
-      my @tests = Path::Tiny::path('.')->children( qr/.*test.*/ );
-      $_->remove_tree for @tests;
-      Path::Tiny::path('graphics')->remove_tree;
-      Path::Tiny::path('setup.py')->remove_tree;
-    };
-    plugin 'Build::Copy';
-    after build => sub {
-      my($build) = @_;
-      $build->runtime_prop->{'style'} = 'source';
-      $build->runtime_prop->{'python-source'} = 1;
-      $build->runtime_prop->{command} = 'meson.py';
-      $build->runtime_prop->{python_bin} = $python_bin;
-    };
+  } elsif( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'binary' ) {
+    can_binary();
+    do_binary();
+  } elsif( $ENV{ALIEN_MESON_SHARE_PREFER} eq 'source') {
+    can_source();
+    do_source();
   }
 
 };


### PR DESCRIPTION
This allows for more specific control over which kind of release to use
(automatic, prefer source, prefer binary).

Fixes <https://github.com/PerlAlien/Alien-Meson/issues/5>.
